### PR TITLE
Possible fix for timezone issues with travis #18

### DIFF
--- a/test/src/com/complexible/common/utils/Dates2Test.java
+++ b/test/src/com/complexible/common/utils/Dates2Test.java
@@ -1,15 +1,23 @@
 package com.complexible.common.utils;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
 
 public class Dates2Test {
+
+    @Before
+    public void setup() {
+        // so that serialized dates get same TZ as reference data, not local TZ
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Budapest"));
+    }
 
     @Test
     public void testAsDate() {


### PR DESCRIPTION
Travis build had errors with timezone on dates2test:
<img width="825" alt="Képernyőfotó 2019-05-20 - 20 40 19" src="https://user-images.githubusercontent.com/31635318/58045183-04cb4880-7b42-11e9-8450-373280856dc6.png">

But now it looks good:
<img width="1081" alt="Képernyőfotó 2019-05-20 - 20 58 48" src="https://user-images.githubusercontent.com/31635318/58045213-144a9180-7b42-11e9-97af-c36de726e388.png">


